### PR TITLE
Add ssh key action

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Add this repository using `git submodule` to your packages:
 ```shell
 git submodule add https://github.com/saeghe/github-template.git .github
 ```
+
+## Usage on GitHub
+
+You need to add a ssh key to your project secrets as `SSH_PRIVATE_KEY`.

--- a/workflows/run-tests.yml
+++ b/workflows/run-tests.yml
@@ -30,6 +30,16 @@ jobs:
           extensions: curl, mbstring, zip
           coverage: none
 
+      - name: Add SSH key
+        uses: webfactory/ssh-agent@v0.6.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Install dependencies
+        run: |
+          git submodule init
+          git submodule update
+
       - name: Install Saeghe
         run: bash -c "$(curl -fsSL https://raw.github.com/saeghe/installation/master/install.sh)"
 


### PR DESCRIPTION
We need to add a `SSH_PRIVATE_KEY` for all actions since they are going to use submodule to install the `github-template` repository. This PR adds the action.
